### PR TITLE
For your consideration

### DIFF
--- a/lib/app/bloc/meeting/meeting_bloc.dart
+++ b/lib/app/bloc/meeting/meeting_bloc.dart
@@ -50,8 +50,8 @@ class MeetingBloc extends Bloc<MeetingEvent, MeetingState> {
     return await _repository.getSignedUser();
   }
 
-  void create(Meeting meeting) {
-    _repository.saveMeetingCollection(meeting);
+  Future<String> create(Meeting meeting) {
+    return _repository.saveMeetingCollection(meeting);
   }
 
   void update(Meeting meeting) {

--- a/lib/app/repository/firestore_provider.dart
+++ b/lib/app/repository/firestore_provider.dart
@@ -1,14 +1,22 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class FirestoreProvider {
+  static const String _COLLECTION_MEETINGS = "meetings";
+
   Firestore _firestore = Firestore.instance;
 
-  void saveMeetingCollection(Map<String, dynamic> data) {
-    _firestore.collection("meetings").document().setData({'meeting': data, 'merge': true});
+  Future<String> saveMeetingCollection(Map<String, dynamic> data) async {
+    var documentRef = await _firestore.collection(_COLLECTION_MEETINGS).add({'meeting': data, 'merge': true});
+
+    return documentRef?.documentID;
   }
 
   void updateMeetingCollection(Map<String, dynamic> data, String id) {
-    _firestore.collection("meetings").document(id).updateData({'meeting': data, 'merge': true});
+    _firestore.collection(_COLLECTION_MEETINGS).document(id).updateData({'meeting': data, 'merge': true});
+  }
+
+  Stream<QuerySnapshot> getActiveMeetings() {
+    return _firestore.collection(_COLLECTION_MEETINGS).where("expiredTime", isGreaterThan: DateTime.now()).snapshots();
   }
 
   void saveUserCollection(Map<String, dynamic> data, String id) {

--- a/lib/app/repository/repository.dart
+++ b/lib/app/repository/repository.dart
@@ -64,8 +64,8 @@ class UserRepository extends Repository {
 }
 
 class MeetingRepository extends Repository {
-  void saveMeetingCollection(Meeting meeting) {
-    _firestoreProvider.saveMeetingCollection(meeting.toJson());
+  Future<String> saveMeetingCollection(Meeting meeting) {
+    return _firestoreProvider.saveMeetingCollection(meeting.toJson());
   }
 
   void updateMeetingCollection(Meeting meeting) {


### PR DESCRIPTION
Renato,
Esse PR é só pra ver como queres que a gente pegue as informações. Tem só duas mudanças.
1) Estou retornando o document id quando criamos uma nova meeting. Isso não vai servir pra nada pra gente, e foi colocado só pra eu aprender como faz. Mas temos como fazer direto DocumentReferences e CollectionReferences.
2) A parte que eu realmente quero que olhes é o getActiveMeetings em firestore_provider.dart. Acho que é um jeito legal de pegar um observável das meetings, para ir atualizando na tela enquanto elas vão sendo criadas. Que achas?